### PR TITLE
Provide GPG key material as environment variable to BouncyCastle GPG signer.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,13 +67,12 @@ jobs:
         server-id: maven-central
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
-        gpg-passphrase:  MAVEN_GPG_PASSPHRASE
-        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
 
     - name: Publish to the Maven Central Repository
       run: mvn --batch-mode --activate-profiles maven-central deploy
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        MAVEN_GPG_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         MAVEN_GPG_KEY_FINGERPRINT: ${{ vars.MAVEN_GPG_KEY_FINGERPRINT }}


### PR DESCRIPTION
This PR fixes a small problem where I forgot to provide the actual GPG key material to the Maven GPG signing plugin.